### PR TITLE
fix: clear expired auth sessions

### DIFF
--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -2,6 +2,7 @@ import { FastifyRequest, FastifyReply } from "fastify"
 import { workos } from "../config/workos.js"
 import { env } from "../config/env.js"
 import { logSecurityEvent } from "./securityLogger.js"
+import { clearSessionCookie, setSessionCookie } from "../utils/sessionCookie.js"
 
 export interface AuthenticatedRequest extends FastifyRequest {
     user?: {
@@ -47,12 +48,7 @@ export async function authenticateUser(
                     refreshResult.sealedSession
                 ) {
                     // Update the cookie with the new session
-                    reply.setCookie("wos-session", refreshResult.sealedSession, {
-                        path: "/",
-                        httpOnly: true,
-                        secure: env.NODE_ENV === "production",
-                        sameSite: env.NODE_ENV === "production" ? "none" : "lax"
-                    })
+                    setSessionCookie(reply, refreshResult.sealedSession)
 
                     request.user = {
                         id: refreshResult.user.id,
@@ -69,6 +65,7 @@ export async function authenticateUser(
             logSecurityEvent(request, reply, "authentication_failure", {
                 reason: "Invalid or expired session"
             })
+            clearSessionCookie(reply)
             reply.code(401).send({ error: "Unauthorized: Invalid or expired session" })
             return
         }
@@ -85,6 +82,7 @@ export async function authenticateUser(
             reason: "Failed to authenticate session",
             error: error instanceof Error ? error.message : String(error)
         })
+        clearSessionCookie(reply)
         reply.code(401).send({ error: "Unauthorized: Failed to authenticate session" })
         return
     }

--- a/backend/src/middleware/csrf.ts
+++ b/backend/src/middleware/csrf.ts
@@ -24,7 +24,7 @@ export function setCsrfToken(reply: FastifyReply, token: string, request: Fastif
     }
 
     reply.setCookie(CSRF_TOKEN_COOKIE_NAME, token, {
-        httpOnly: false,
+        httpOnly: true,
         secure: env.NODE_ENV === "production",
         sameSite: env.NODE_ENV === "production" ? "none" : "lax",
         path: "/",

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -9,6 +9,7 @@ import { zodToFastifySchema } from "../utils/schema.js"
 import { authenticateUser, type AuthenticatedRequest } from "../middleware/auth.js"
 import { logger } from "../utils/logger.js"
 import { trackEvent } from "../utils/tracker.js"
+import { clearSessionCookie, setSessionCookie } from "../utils/sessionCookie.js"
 
 const DEFAULT_POST_AUTH_PATH = "/"
 
@@ -203,14 +204,7 @@ export async function authRoutes(fastify: FastifyInstance) {
             // For cross-origin requests (frontend on different subdomain), we need:
             // - sameSite: "none" (allows cross-origin cookies)
             // - secure: true (required when sameSite is "none")
-            const cookieOptions = {
-                path: "/",
-                httpOnly: true,
-                secure: env.NODE_ENV === "production",
-                sameSite: (env.NODE_ENV === "production" ? "none" : "lax") as "none" | "lax"
-            }
-
-            reply.setCookie("wos-session", sealedSession, cookieOptions)
+            setSessionCookie(reply, sealedSession)
 
             if (env.NODE_ENV === "development") {
                 fastify.log.info(
@@ -309,12 +303,7 @@ export async function authRoutes(fastify: FastifyInstance) {
                 }
 
                 // Clear the session cookie
-                reply.clearCookie("wos-session", {
-                    path: "/",
-                    httpOnly: true,
-                    secure: env.NODE_ENV === "production",
-                    sameSite: (env.NODE_ENV === "production" ? "none" : "lax") as "none" | "lax"
-                })
+                clearSessionCookie(reply)
 
                 await trackEvent(
                     "auth_logout",
@@ -340,12 +329,7 @@ export async function authRoutes(fastify: FastifyInstance) {
                     method: "GET"
                 })
                 // Clear cookie even on error
-                reply.clearCookie("wos-session", {
-                    path: "/",
-                    httpOnly: true,
-                    secure: env.NODE_ENV === "production",
-                    sameSite: (env.NODE_ENV === "production" ? "none" : "lax") as "none" | "lax"
-                })
+                clearSessionCookie(reply)
                 reply.send({
                     success: true,
                     logoutUrl: null
@@ -380,16 +364,25 @@ export async function authRoutes(fastify: FastifyInstance) {
                 return
             }
 
-            const session = workos.userManagement.loadSealedSession({
-                sessionData,
-                cookiePassword
-            })
+            let sessionUser: {
+                id: string
+                email: string
+                firstName?: string | null
+                lastName?: string | null
+            }
+            let sessionRefreshed = false
 
-            const authResult = await session.authenticate()
+            try {
+                const session = workos.userManagement.loadSealedSession({
+                    sessionData,
+                    cookiePassword
+                })
 
-            if (!authResult.authenticated || !("user" in authResult)) {
-                // Try to refresh the session
-                try {
+                const authResult = await session.authenticate()
+
+                if (authResult.authenticated && "user" in authResult) {
+                    sessionUser = authResult.user
+                } else {
                     const refreshResult = await session.refresh()
                     if (
                         refreshResult.authenticated &&
@@ -397,50 +390,20 @@ export async function authRoutes(fastify: FastifyInstance) {
                         "user" in refreshResult &&
                         refreshResult.sealedSession
                     ) {
-                        // Update the cookie with the new session
-                        reply.setCookie("wos-session", refreshResult.sealedSession, {
-                            path: "/",
-                            httpOnly: true,
-                            secure: env.NODE_ENV === "production",
-                            sameSite: (env.NODE_ENV === "production" ? "none" : "lax") as
-                                | "none"
-                                | "lax"
-                        })
-
-                        // Get user from database to include nickname
-                        const dbUser = await db.query.users.findFirst({
-                            where: eq(schema.users.id, refreshResult.user.id)
-                        })
-
-                        await trackEvent(
-                            "auth_me_success",
-                            {
-                                endpoint: "/auth/me",
-                                method: "GET",
-                                userId: refreshResult.user.id,
-                                sessionRefreshed: true
-                            },
-                            refreshResult.user.id,
-                            request
-                        )
-
-                        reply.send({
-                            id: refreshResult.user.id,
-                            email: refreshResult.user.email,
-                            firstName: refreshResult.user.firstName,
-                            lastName: refreshResult.user.lastName,
-                            nickname: dbUser?.nickname || null
-                        })
-                        return
+                        setSessionCookie(reply, refreshResult.sealedSession)
+                        sessionUser = refreshResult.user
+                        sessionRefreshed = true
+                    } else {
+                        throw new Error("Session is invalid")
                     }
-                } catch (_refreshError) {
-                    // Refresh failed, return unauthorized
                 }
-
+            } catch (error) {
                 logger.warn("Session is invalid", {
                     endpoint: "/auth/me",
-                    method: "GET"
+                    method: "GET",
+                    error: error instanceof Error ? error.message : String(error)
                 })
+                clearSessionCookie(reply)
                 reply.code(401).send({
                     error: "Unauthorized",
                     message: "Session is invalid"
@@ -448,36 +411,30 @@ export async function authRoutes(fastify: FastifyInstance) {
                 return
             }
 
-            if ("user" in authResult) {
-                // Get user from database to include nickname
-                const dbUser = await db.query.users.findFirst({
-                    where: eq(schema.users.id, authResult.user.id)
-                })
+            // Get user from database to include nickname
+            const dbUser = await db.query.users.findFirst({
+                where: eq(schema.users.id, sessionUser.id)
+            })
 
-                await trackEvent(
-                    "auth_me_success",
-                    {
-                        endpoint: "/auth/me",
-                        method: "GET",
-                        userId: authResult.user.id
-                    },
-                    authResult.user.id,
-                    request
-                )
+            await trackEvent(
+                "auth_me_success",
+                {
+                    endpoint: "/auth/me",
+                    method: "GET",
+                    userId: sessionUser.id,
+                    ...(sessionRefreshed ? { sessionRefreshed: true } : {})
+                },
+                sessionUser.id,
+                request
+            )
 
-                reply.send({
-                    id: authResult.user.id,
-                    email: authResult.user.email,
-                    firstName: authResult.user.firstName,
-                    lastName: authResult.user.lastName,
-                    nickname: dbUser?.nickname || null
-                })
-            } else {
-                reply.code(401).send({
-                    error: "Unauthorized",
-                    message: "Session is invalid"
-                })
-            }
+            reply.send({
+                id: sessionUser.id,
+                email: sessionUser.email,
+                firstName: sessionUser.firstName,
+                lastName: sessionUser.lastName,
+                nickname: dbUser?.nickname || null
+            })
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : "Failed to get user"
             fastify.log.error({ err: error }, "Get user error")

--- a/backend/src/utils/sessionCookie.ts
+++ b/backend/src/utils/sessionCookie.ts
@@ -1,0 +1,17 @@
+import { FastifyReply } from "fastify"
+import { env } from "../config/env.js"
+
+const getSessionCookieOptions = () => ({
+    path: "/",
+    httpOnly: true,
+    secure: env.NODE_ENV === "production",
+    sameSite: (env.NODE_ENV === "production" ? "none" : "lax") as "none" | "lax"
+})
+
+export const setSessionCookie = (reply: FastifyReply, sealedSession: string) => {
+    reply.setCookie("wos-session", sealedSession, getSessionCookieOptions())
+}
+
+export const clearSessionCookie = (reply: FastifyReply) => {
+    reply.clearCookie("wos-session", getSessionCookieOptions())
+}

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { useEffect } from "react"
-import { api, API_URL } from "../utils/api"
+import { api, API_URL, type ApiError } from "../utils/api"
 import { PREFERENCES_QUERY_KEY } from "./useUserPreferences"
 import posthog from "posthog-js"
 
@@ -49,12 +49,13 @@ export const useAuth = () => {
     const {
         data: user,
         isLoading,
+        isFetching,
         refetch
     } = useQuery({
         queryKey: ["auth", "me"],
         queryFn: () => api.getCurrentUser(),
         retry: (failureCount, error) => {
-            const status = (error as Error & { status?: number })?.status
+            const status = (error as ApiError)?.status
             if (status && status >= 400 && status < 500) {
                 return false
             }
@@ -64,23 +65,28 @@ export const useAuth = () => {
             return false
         },
         retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 3000), // Exponential backoff
-        staleTime: 5 * 60 * 1000 // 5 minutes
+        staleTime: 5 * 60 * 1000, // 5 minutes
+        refetchOnMount: "always",
+        refetchOnWindowFocus: true
     })
+
+    const isValidatingCachedAuth = !!user && isFetching
+    const currentUser = isValidatingCachedAuth ? null : (user ?? null)
 
     // Identify user in PostHog when query succeeds (for already-authenticated users)
     useEffect(() => {
-        if (user) {
+        if (currentUser) {
             try {
-                posthog.identify(user.id, {
-                    email: user.email,
-                    firstName: user.firstName,
-                    lastName: user.lastName
+                posthog.identify(currentUser.id, {
+                    email: currentUser.email,
+                    firstName: currentUser.firstName,
+                    lastName: currentUser.lastName
                 })
             } catch (error) {
                 console.warn("PostHog identify failed:", error)
             }
         }
-    }, [user])
+    }, [currentUser])
 
     const refreshAuth = async () => {
         // Invalidate the query cache first to force a fresh fetch
@@ -166,9 +172,9 @@ export const useAuth = () => {
     })
 
     return {
-        user: user ?? null,
-        isLoading,
-        isAuthenticated: !!user,
+        user: currentUser,
+        isLoading: isLoading || isValidatingCachedAuth,
+        isAuthenticated: !!currentUser,
         signIn,
         signOut,
         refreshAuth,

--- a/frontend/src/hooks/useCoteries.tsx
+++ b/frontend/src/hooks/useCoteries.tsx
@@ -1,17 +1,19 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { api } from "../utils/api"
 
-export const useCoteries = () => {
+export const useCoteries = (enabled = true) => {
     return useQuery({
         queryKey: ["coteries"],
-        queryFn: () => api.getCoteries()
+        queryFn: () => api.getCoteries(),
+        enabled
     })
 }
 
 export const useCoterie = (id: string | null) => {
     return useQuery({
         queryKey: ["coteries", id],
-        queryFn: () => (id ? api.getCoterie(id) : null)
+        queryFn: () => (id ? api.getCoterie(id) : null),
+        enabled: !!id
     })
 }
 

--- a/frontend/src/pages/MePage.tsx
+++ b/frontend/src/pages/MePage.tsx
@@ -199,8 +199,8 @@ const MePage = () => {
         isUpdatingProfile,
         signOut
     } = useAuth()
-    const { data: characters } = useCharacters()
-    const { data: coteries } = useCoteries()
+    const { data: characters } = useCharacters(isAuthenticated)
+    const { data: coteries } = useCoteries(isAuthenticated)
     const [character, setCharacter] = useCharacterLocalStorage()
     const computedColorScheme = useComputedColorScheme("dark", {
         getInitialValueInEffect: true

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -3,21 +3,54 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { createTheme, MantineProvider } from "@mantine/core"
 import { generateColors } from "@mantine/colors-generator"
 import { Notifications } from "@mantine/notifications"
+import { useEffect } from "react"
+import posthog from "posthog-js"
 import { PostHogProvider } from "posthog-js/react"
 import { globals } from "~/globals"
 import BrokenSaveModal from "~/components/BrokenSaveModal"
 import { CookiesBanner } from "~/components/CookiesBanner"
 import { inputFocusTheme } from "~/theme/inputFocus"
+import { AUTH_UNAUTHORIZED_EVENT, type ApiError } from "~/utils/api"
 
 const queryClient = new QueryClient({
     defaultOptions: {
         queries: {
             staleTime: 5 * 60 * 1000,
-            retry: 1,
+            retry: (failureCount, error) => {
+                const status = (error as ApiError)?.status
+                if (status && status >= 400 && status < 500) {
+                    return false
+                }
+
+                return failureCount < 1
+            },
             refetchOnWindowFocus: false
         }
     }
 })
+
+const AuthUnauthorizedHandler = () => {
+    useEffect(() => {
+        const handleUnauthorized = () => {
+            queryClient.setQueryData(["auth", "me"], null)
+            queryClient.removeQueries({ queryKey: ["characters"] })
+            queryClient.removeQueries({ queryKey: ["coteries"] })
+            queryClient.removeQueries({ queryKey: ["shares"] })
+            queryClient.removeQueries({ queryKey: ["user", "preferences"] })
+
+            try {
+                posthog.reset()
+            } catch (error) {
+                console.warn("PostHog reset failed:", error)
+            }
+        }
+
+        window.addEventListener(AUTH_UNAUTHORIZED_EVENT, handleUnauthorized)
+        return () => window.removeEventListener(AUTH_UNAUTHORIZED_EVENT, handleUnauthorized)
+    }, [])
+
+    return null
+}
 
 export const Route = createRootRoute({
     component: () => (
@@ -86,6 +119,7 @@ export const Route = createRootRoute({
                     forceColorScheme="dark"
                 >
                     <Notifications position="bottom-center" zIndex={3000} />
+                    <AuthUnauthorizedHandler />
                     <BrokenSaveModal />
                     <CookiesBanner />
                     <Outlet />

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -23,6 +23,16 @@ type RequestOptions = {
     headers?: Record<string, string>
 }
 
+export const AUTH_UNAUTHORIZED_EVENT = "progeny:auth-unauthorized"
+
+export type ApiError = Error & { status?: number }
+
+const notifyAuthUnauthorized = () => {
+    if (typeof window !== "undefined") {
+        window.dispatchEvent(new Event(AUTH_UNAUTHORIZED_EVENT))
+    }
+}
+
 // TODOdin: We're now getting token from header because of domain conflict issues
 // TODOdin: Switch to JWT-in-header auth (like in cozycrowns) and ditch all CSRF stuff
 // verify that what we're doing now is legit and good practice
@@ -95,8 +105,11 @@ const apiRequest = async <T>(endpoint: string, options: RequestOptions = {}): Pr
     if (!response.ok) {
         const error = await response.json().catch(() => ({ error: "Unknown error" }))
         const errorMessage = error.message || error.error || `HTTP ${response.status}`
-        const httpError = new Error(errorMessage) as Error & { status?: number }
+        const httpError = new Error(errorMessage) as ApiError
         httpError.status = response.status
+        if (response.status === 401) {
+            notifyAuthUnauthorized()
+        }
         throw httpError
     }
 
@@ -135,13 +148,14 @@ export const api = {
         }
 
         if (response.status === 401) {
+            notifyAuthUnauthorized()
             return null
         }
 
         if (!response.ok) {
             const error = await response.json().catch(() => ({ error: "Unknown error" }))
             const errorMessage = error.message || error.error || `HTTP ${response.status}`
-            const httpError = new Error(errorMessage) as Error & { status?: number }
+            const httpError = new Error(errorMessage) as ApiError
             httpError.status = response.status
             throw httpError
         }


### PR DESCRIPTION
## Summary
- clear stale frontend auth/protected React Query caches when backend auth returns 401
- revalidate cached auth on mount/focus before showing account UI
- clear invalid WorkOS session cookies server-side and make the CSRF cookie httpOnly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Security**
  * Strengthened CSRF token protection against unauthorized client-side access.

* **Bug Fixes**
  * Improved handling of session expiration and unauthorized access scenarios.
  * Better authentication state recovery with automatic cache cleanup on logout.

* **Performance**
  * Optimized data loading to execute conditionally based on authentication state.
  * Improved API request retry logic for more intelligent error recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->