### PR TITLE
Add live coterie vitals

### DIFF
--- a/backend/src/coteries.test.ts
+++ b/backend/src/coteries.test.ts
@@ -184,7 +184,18 @@ const seedBaseData = async () => {
             id: OWNER_CHARACTER_ID,
             userId: OWNER_ID,
             name: "Owner Character",
-            data: JSON.stringify({ name: "Owner Character", player: "Owner" }),
+            data: JSON.stringify({
+                name: "Owner Character",
+                player: "Owner",
+                willpower: 6,
+                humanity: 7,
+                ephemeral: {
+                    hunger: 2,
+                    superficialWillpowerDamage: 1,
+                    aggravatedWillpowerDamage: 1,
+                    humanityStains: 1
+                }
+            }),
             version: 1,
             characterVersion: 0
         },
@@ -192,7 +203,18 @@ const seedBaseData = async () => {
             id: MEMBER_CHARACTER_ID,
             userId: MEMBER_ID,
             name: "Member Character",
-            data: JSON.stringify({ name: "Member Character", player: "Character Sheet Player" }),
+            data: JSON.stringify({
+                name: "Member Character",
+                player: "Character Sheet Player",
+                willpower: 5,
+                humanity: 6,
+                ephemeral: {
+                    hunger: 3,
+                    superficialWillpowerDamage: 1,
+                    aggravatedWillpowerDamage: 0,
+                    humanityStains: 2
+                }
+            }),
             version: 1,
             characterVersion: 0
         },
@@ -200,7 +222,18 @@ const seedBaseData = async () => {
             id: OTHER_CHARACTER_ID,
             userId: OTHER_ID,
             name: "Other Character",
-            data: JSON.stringify({ name: "Other Character", player: "Other" }),
+            data: JSON.stringify({
+                name: "Other Character",
+                player: "Other",
+                willpower: 4,
+                humanity: 5,
+                ephemeral: {
+                    hunger: 1,
+                    superficialWillpowerDamage: 0,
+                    aggravatedWillpowerDamage: 0,
+                    humanityStains: 0
+                }
+            }),
             version: 1,
             characterVersion: 0
         }
@@ -257,6 +290,116 @@ describe("coterie invites and membership permissions", () => {
         setWorkosUser(OWNER_ID)
         await cleanup()
         await seedBaseData()
+    })
+
+    it("updates and shares lightweight live vitals with every coterie participant", async () => {
+        const ownerVitalsResponse = await app.inject({
+            method: "GET",
+            url: "/coteries/vitals",
+            headers: csrfHeaders
+        })
+        expect(ownerVitalsResponse.statusCode).toBe(200)
+        expect(ownerVitalsResponse.json()).toEqual([
+            expect.objectContaining({
+                coterieId: COTERIE_ID,
+                characterId: OWNER_CHARACTER_ID,
+                hunger: 2,
+                currentWillpower: 4,
+                willpower: 6,
+                humanity: 7,
+                humanityStains: 1
+            })
+        ])
+
+        const updateResponse = await app.inject({
+            method: "PATCH",
+            url: `/characters/${OWNER_CHARACTER_ID}/vitals`,
+            headers: csrfHeaders,
+            payload: {
+                willpower: 7,
+                humanity: 6,
+                ephemeral: {
+                    hunger: 4,
+                    superficialWillpowerDamage: 2,
+                    aggravatedWillpowerDamage: 1,
+                    humanityStains: 3
+                }
+            }
+        })
+        expect(updateResponse.statusCode).toBe(200)
+        expect(updateResponse.json().characterVersion).toBe(1)
+
+        const refreshedOwnerVitalsResponse = await app.inject({
+            method: "GET",
+            url: "/coteries/vitals",
+            headers: csrfHeaders
+        })
+        expect(refreshedOwnerVitalsResponse.json()).toEqual([
+            expect.objectContaining({
+                characterId: OWNER_CHARACTER_ID,
+                hunger: 4,
+                currentWillpower: 4,
+                willpower: 7,
+                humanity: 6,
+                humanityStains: 3,
+                characterVersion: 1
+            })
+        ])
+
+        const invite = await createInvite(app)
+        setWorkosUser(MEMBER_ID)
+        const acceptResponse = await app.inject({
+            method: "POST",
+            url: `/coterie-invites/${invite.token}/accept`,
+            headers: csrfHeaders
+        })
+        expect(acceptResponse.statusCode).toBe(200)
+
+        const addCharacterResponse = await app.inject({
+            method: "POST",
+            url: `/coteries/${COTERIE_ID}/characters`,
+            headers: csrfHeaders,
+            payload: { characterId: MEMBER_CHARACTER_ID }
+        })
+        expect(addCharacterResponse.statusCode).toBe(201)
+
+        const memberVitalsResponse = await app.inject({
+            method: "GET",
+            url: "/coteries/vitals",
+            headers: csrfHeaders
+        })
+        expect(memberVitalsResponse.statusCode).toBe(200)
+        expect(
+            (memberVitalsResponse.json() as Array<{ characterId: string }>).map(
+                ({ characterId }) => characterId
+            )
+        ).toEqual(expect.arrayContaining([OWNER_CHARACTER_ID, MEMBER_CHARACTER_ID]))
+
+        const forbiddenUpdateResponse = await app.inject({
+            method: "PATCH",
+            url: `/characters/${OWNER_CHARACTER_ID}/vitals`,
+            headers: csrfHeaders,
+            payload: {
+                willpower: 6,
+                humanity: 6,
+                ephemeral: {
+                    hunger: 1,
+                    superficialWillpowerDamage: 0,
+                    aggravatedWillpowerDamage: 0,
+                    humanityStains: 0
+                }
+            }
+        })
+        expect(forbiddenUpdateResponse.statusCode).toBe(403)
+
+        setWorkosUser(OTHER_ID)
+        const unrelatedUserResponse = await app.inject({
+            method: "GET",
+            url: "/coteries/vitals",
+            headers: csrfHeaders
+        })
+        expect(unrelatedUserResponse.statusCode).toBe(200)
+        expect(unrelatedUserResponse.json()).toEqual([])
     })
 
     it("lists newest invite links first with stable same-second ordering", async () => {

--- a/backend/src/routes/characters.ts
+++ b/backend/src/routes/characters.ts
@@ -5,10 +5,12 @@ import { authenticateUser, AuthenticatedRequest } from "../middleware/auth.js"
 import {
     createCharacterSchema,
     updateCharacterSchema,
+    updateCharacterVitalsSchema,
     characterParamsSchema,
     CreateCharacterInput,
     CharacterParams,
-    UpdateCharacterInput
+    UpdateCharacterInput,
+    UpdateCharacterVitalsInput
 } from "../schemas/character.js"
 import { nanoid } from "nanoid"
 import { zodToFastifySchema } from "../utils/schema.js"
@@ -361,6 +363,85 @@ export async function characterRoutes(fastify: FastifyInstance) {
                 reply.code(500).send({
                     error: "Internal server error",
                     message: error instanceof Error ? error.message : "Failed to update character"
+                })
+            }
+        }
+    )
+
+    // Update character play-state vitals only
+    fastify.patch<{
+        Params: CharacterParams
+        Body: UpdateCharacterVitalsInput
+    }>(
+        "/characters/:id/vitals",
+        {
+            preHandler: authenticateUser,
+            schema: {
+                params: zodToFastifySchema(characterParamsSchema),
+                body: zodToFastifySchema(updateCharacterVitalsSchema)
+            }
+        },
+        async (request: AuthenticatedRequest, reply) => {
+            const { id: characterId } = request.params as CharacterParams
+            const updateData = request.body as UpdateCharacterVitalsInput
+            try {
+                const userId = request.user!.id
+
+                const character = await db.query.characters.findFirst({
+                    where: eq(schema.characters.id, characterId)
+                })
+
+                if (!character) {
+                    reply.code(404).send({ error: "Character not found" })
+                    return
+                }
+
+                if (character.userId !== userId) {
+                    reply
+                        .code(403)
+                        .send({ error: "Forbidden: You can only edit your own characters" })
+                    return
+                }
+
+                const currentData = JSON.parse(character.data)
+                const newCharacterVersion = (character.characterVersion ?? 0) + 1
+                const updatedData = {
+                    ...currentData,
+                    willpower: updateData.willpower,
+                    humanity: updateData.humanity,
+                    ephemeral: {
+                        ...currentData.ephemeral,
+                        ...updateData.ephemeral
+                    },
+                    characterVersion: newCharacterVersion
+                }
+
+                const [updated] = await db
+                    .update(schema.characters)
+                    .set({
+                        data: JSON.stringify(updatedData),
+                        characterVersion: newCharacterVersion,
+                        updatedAt: new Date()
+                    })
+                    .where(eq(schema.characters.id, characterId))
+                    .returning()
+
+                reply.send({
+                    id: updated.id,
+                    characterVersion: updated.characterVersion,
+                    updatedAt: updated.updatedAt
+                })
+            } catch (error) {
+                logger.error("Failed to update character vitals", error, {
+                    endpoint: "/characters/:id/vitals",
+                    method: "PATCH",
+                    userId: request.user?.id ?? null,
+                    characterId
+                })
+                reply.code(500).send({
+                    error: "Internal server error",
+                    message:
+                        error instanceof Error ? error.message : "Failed to update character vitals"
                 })
             }
         }

--- a/backend/src/routes/coteries.ts
+++ b/backend/src/routes/coteries.ts
@@ -48,10 +48,7 @@ const inviteUnavailableReply = { error: "Invite link is invalid or expired" }
 
 const getUtf8ByteLength = (value: string) => Buffer.byteLength(value, "utf8")
 
-const tokenizeNoteWords = (value: string) =>
-    value
-        .toLowerCase()
-        .match(/[\p{L}\p{N}']+/gu) ?? []
+const tokenizeNoteWords = (value: string) => value.toLowerCase().match(/[\p{L}\p{N}']+/gu) ?? []
 
 const getMultisetWordDelta = (previous: string, next: string) => {
     const counts = new Map<string, number>()
@@ -240,9 +237,7 @@ const buildCoterieResponse = async (
                   .from(schema.users)
                   .where(inArray(schema.users.id, characterOwnerIds))
             : []
-    const nicknameByUserId = new Map(
-        characterOwners.map((owner) => [owner.id, owner.nickname])
-    )
+    const nicknameByUserId = new Map(characterOwners.map((owner) => [owner.id, owner.nickname]))
 
     return {
         ...withoutOwnerId(coterie),
@@ -281,6 +276,61 @@ const requireOwnedCoterie = async (coterieId: string, userId: string) => {
     }
 
     return { coterie, errorCode: null, error: null }
+}
+
+const parseCharacterVitals = (data: string) => {
+    try {
+        const character = JSON.parse(data) as {
+            willpower?: unknown
+            humanity?: unknown
+            ephemeral?: {
+                hunger?: unknown
+                superficialWillpowerDamage?: unknown
+                aggravatedWillpowerDamage?: unknown
+                humanityStains?: unknown
+            }
+        }
+        const willpower = typeof character.willpower === "number" ? character.willpower : null
+        const humanity = typeof character.humanity === "number" ? character.humanity : null
+        const hunger =
+            typeof character.ephemeral?.hunger === "number" ? character.ephemeral.hunger : null
+        const superficialWillpowerDamage =
+            typeof character.ephemeral?.superficialWillpowerDamage === "number"
+                ? character.ephemeral.superficialWillpowerDamage
+                : null
+        const aggravatedWillpowerDamage =
+            typeof character.ephemeral?.aggravatedWillpowerDamage === "number"
+                ? character.ephemeral.aggravatedWillpowerDamage
+                : null
+        const humanityStains =
+            typeof character.ephemeral?.humanityStains === "number"
+                ? character.ephemeral.humanityStains
+                : null
+
+        if (
+            willpower === null ||
+            humanity === null ||
+            hunger === null ||
+            superficialWillpowerDamage === null ||
+            aggravatedWillpowerDamage === null ||
+            humanityStains === null
+        ) {
+            return null
+        }
+
+        return {
+            hunger,
+            willpower,
+            humanity,
+            humanityStains,
+            currentWillpower: Math.max(
+                willpower - superficialWillpowerDamage - aggravatedWillpowerDamage,
+                0
+            )
+        }
+    } catch (_error) {
+        return null
+    }
 }
 
 export async function coterieRoutes(fastify: FastifyInstance) {
@@ -454,6 +504,69 @@ export async function coterieRoutes(fastify: FastifyInstance) {
             )
 
             reply.send(allCoteries)
+        }
+    )
+
+    // Get lightweight live vitals for coterie member characters
+    fastify.get(
+        "/coteries/vitals",
+        {
+            preHandler: authenticateUser
+        },
+        async (request: AuthenticatedRequest, reply) => {
+            const userId = request.user!.id
+
+            const [ownedCoteries, playerMemberships] = await Promise.all([
+                db
+                    .select({ coterieId: schema.coteries.id })
+                    .from(schema.coteries)
+                    .where(eq(schema.coteries.ownerId, userId)),
+                db
+                    .select({ coterieId: schema.coteriePlayerMemberships.coterieId })
+                    .from(schema.coteriePlayerMemberships)
+                    .where(eq(schema.coteriePlayerMemberships.userId, userId))
+            ])
+            const accessibleCoterieIds = Array.from(
+                new Set([
+                    ...ownedCoteries.map(({ coterieId }) => coterieId),
+                    ...playerMemberships.map(({ coterieId }) => coterieId)
+                ])
+            )
+
+            if (accessibleCoterieIds.length === 0) {
+                reply.send([])
+                return
+            }
+
+            const rows = await db
+                .select({
+                    coterieId: schema.coterieMembers.coterieId,
+                    characterId: schema.characters.id,
+                    data: schema.characters.data,
+                    characterVersion: schema.characters.characterVersion,
+                    updatedAt: schema.characters.updatedAt
+                })
+                .from(schema.coterieMembers)
+                .innerJoin(
+                    schema.characters,
+                    eq(schema.characters.id, schema.coterieMembers.characterId)
+                )
+                .where(inArray(schema.coterieMembers.coterieId, accessibleCoterieIds))
+
+            reply.send(
+                rows.flatMap((row) => {
+                    const vitals = parseCharacterVitals(row.data)
+                    if (!vitals) return []
+
+                    return {
+                        coterieId: row.coterieId,
+                        characterId: row.characterId,
+                        characterVersion: row.characterVersion,
+                        updatedAt: row.updatedAt,
+                        ...vitals
+                    }
+                })
+            )
         }
     )
 
@@ -1025,7 +1138,9 @@ export async function coterieRoutes(fastify: FastifyInstance) {
                     coterieId,
                     inviteId,
                     alreadyRevoked: !!invite.revokedAt,
-                    inviteAgeHours: Math.round((Date.now() - invite.createdAt.getTime()) / 3_600_000)
+                    inviteAgeHours: Math.round(
+                        (Date.now() - invite.createdAt.getTime()) / 3_600_000
+                    )
                 },
                 userId,
                 request
@@ -1070,7 +1185,9 @@ export async function coterieRoutes(fastify: FastifyInstance) {
                         coterieId: matchedInvite?.coterieId,
                         inviteId: matchedInvite?.id,
                         inviteAgeHours: matchedInvite
-                            ? Math.round((Date.now() - matchedInvite.createdAt.getTime()) / 3_600_000)
+                            ? Math.round(
+                                  (Date.now() - matchedInvite.createdAt.getTime()) / 3_600_000
+                              )
                             : null
                     },
                     userId,
@@ -1149,7 +1266,9 @@ export async function coterieRoutes(fastify: FastifyInstance) {
                     coterieId: invite.coterieId,
                     inviteId: invite.id,
                     alreadyMember: !!existingMembership,
-                    inviteAgeHours: Math.round((Date.now() - invite.createdAt.getTime()) / 3_600_000)
+                    inviteAgeHours: Math.round(
+                        (Date.now() - invite.createdAt.getTime()) / 3_600_000
+                    )
                 },
                 userId,
                 request
@@ -1429,8 +1548,7 @@ export async function coterieRoutes(fastify: FastifyInstance) {
                         characterId
                     })
                     reply.code(403).send({
-                        error:
-                            "Forbidden: You can only remove your own characters unless you own the coterie"
+                        error: "Forbidden: You can only remove your own characters unless you own the coterie"
                     })
                     return
                 }

--- a/backend/src/schemas/character.ts
+++ b/backend/src/schemas/character.ts
@@ -13,10 +13,22 @@ export const updateCharacterSchema = z.object({
     version: z.number().int().positive().optional()
 })
 
+export const updateCharacterVitalsSchema = z.object({
+    willpower: z.number().min(0).max(10).int(),
+    humanity: z.number().min(0).max(10).int(),
+    ephemeral: z.object({
+        hunger: z.number().min(0).max(5).int(),
+        superficialWillpowerDamage: z.number().min(0).max(10).int(),
+        aggravatedWillpowerDamage: z.number().min(0).max(10).int(),
+        humanityStains: z.number().min(0).max(10).int()
+    })
+})
+
 export const characterParamsSchema = z.object({
     id: z.string().min(1)
 })
 
 export type CreateCharacterInput = z.infer<typeof createCharacterSchema>
 export type UpdateCharacterInput = z.infer<typeof updateCharacterSchema>
+export type UpdateCharacterVitalsInput = z.infer<typeof updateCharacterVitalsSchema>
 export type CharacterParams = z.infer<typeof characterParamsSchema>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -218,6 +218,8 @@ function App() {
         } as CharacterType & { id: string; characterVersion: number })
 
         await queryClient.invalidateQueries({ queryKey: ["characters"] })
+        await queryClient.invalidateQueries({ queryKey: ["coteries"] })
+        await queryClient.invalidateQueries({ queryKey: ["coterieVitals"] })
     }
 
     const isCurrentCharacterEmpty = () =>
@@ -344,6 +346,8 @@ function App() {
                     0
             } as CharacterType & { id: string; characterVersion: number })
             await queryClient.invalidateQueries({ queryKey: ["characters"] })
+            await queryClient.invalidateQueries({ queryKey: ["coteries"] })
+            await queryClient.invalidateQueries({ queryKey: ["coterieVitals"] })
 
             const action = pendingSwitchAction
             closeNameBeforeSwitchModal()

--- a/frontend/src/character_sheet/CharacterSheet.tsx
+++ b/frontend/src/character_sheet/CharacterSheet.tsx
@@ -17,6 +17,7 @@ import posthog from "posthog-js"
 import { getPrimaryColor } from "./utils/style"
 import { type UserPreferences, getBackgroundSrc } from "./utils/preferences"
 import { useUserPreferences } from "~/hooks/useUserPreferences"
+import { useAutosaveCharacterVitals } from "~/hooks/useAutosaveCharacterVitals"
 import type { SetCharacter } from "~/hooks/useCharacterLocalStorage"
 import Attributes from "./sections/Attributes"
 import BottomData from "./sections/BottomData"
@@ -71,6 +72,7 @@ const CharacterSheet = ({ character, setCharacter }: CharacterSheetProps) => {
     const { preferences, updatePreferences } = useUserPreferences()
     const primaryColor = preferences.colorTheme ?? getPrimaryColor(character.clan)
     const sheetTheme = useMemo(() => createTheme({ primaryColor }), [primaryColor])
+    useAutosaveCharacterVitals(character, setCharacter)
 
     const sheetOptions: SheetOptions = useMemo(
         () => ({

--- a/frontend/src/hooks/useAutosaveCharacterVitals.tsx
+++ b/frontend/src/hooks/useAutosaveCharacterVitals.tsx
@@ -1,0 +1,126 @@
+import { useQueryClient } from "@tanstack/react-query"
+import { useEffect, useMemo, useRef } from "react"
+import type { Character } from "~/data/Character"
+import type { SetCharacter } from "~/hooks/useCharacterLocalStorage"
+import { useAuth } from "~/hooks/useAuth"
+import { api } from "~/utils/api"
+
+const AUTOSAVE_DELAY_MS = 750
+const RETRY_DELAY_MS = 3000
+
+const getVitalsKey = (character: Character) =>
+    JSON.stringify({
+        id: character.id || null,
+        hunger: character.ephemeral.hunger,
+        willpower: character.willpower,
+        superficialWillpowerDamage: character.ephemeral.superficialWillpowerDamage,
+        aggravatedWillpowerDamage: character.ephemeral.aggravatedWillpowerDamage,
+        humanity: character.humanity,
+        humanityStains: character.ephemeral.humanityStains
+    })
+
+export const useAutosaveCharacterVitals = (character: Character, setCharacter: SetCharacter) => {
+    const { isAuthenticated } = useAuth()
+    const queryClient = useQueryClient()
+    const latestCharacterRef = useRef(character)
+    const characterIdRef = useRef<string | null>(character.id || null)
+    const lastSavedVitalsKeyRef = useRef<string | null>(null)
+    const setCharacterRef = useRef(setCharacter)
+
+    useEffect(() => {
+        latestCharacterRef.current = character
+    }, [character])
+
+    useEffect(() => {
+        setCharacterRef.current = setCharacter
+    }, [setCharacter])
+
+    const vitalsKey = useMemo(
+        () => getVitalsKey(character),
+        [
+            character.id,
+            character.ephemeral.aggravatedWillpowerDamage,
+            character.ephemeral.hunger,
+            character.ephemeral.humanityStains,
+            character.ephemeral.superficialWillpowerDamage,
+            character.humanity,
+            character.willpower
+        ]
+    )
+
+    useEffect(() => {
+        const characterId = character.id || null
+
+        if (characterIdRef.current !== characterId) {
+            characterIdRef.current = characterId
+            lastSavedVitalsKeyRef.current = vitalsKey
+            return
+        }
+
+        if (!isAuthenticated || !characterId) {
+            lastSavedVitalsKeyRef.current = vitalsKey
+            return
+        }
+
+        if (lastSavedVitalsKeyRef.current === null) {
+            lastSavedVitalsKeyRef.current = vitalsKey
+            return
+        }
+
+        if (lastSavedVitalsKeyRef.current === vitalsKey) return
+
+        let cancelled = false
+        let retryTimeout: number | undefined
+
+        const saveLatestVitals = async () => {
+            const latestCharacter = latestCharacterRef.current
+            if (cancelled || latestCharacter.id !== characterId) return
+
+            const savedVitalsKey = getVitalsKey(latestCharacter)
+
+            try {
+                const savedCharacter = await api.updateCharacterVitals(characterId, {
+                    willpower: latestCharacter.willpower,
+                    humanity: latestCharacter.humanity,
+                    ephemeral: {
+                        hunger: latestCharacter.ephemeral.hunger,
+                        superficialWillpowerDamage:
+                            latestCharacter.ephemeral.superficialWillpowerDamage,
+                        aggravatedWillpowerDamage:
+                            latestCharacter.ephemeral.aggravatedWillpowerDamage,
+                        humanityStains: latestCharacter.ephemeral.humanityStains
+                    }
+                })
+
+                if (cancelled) return
+                lastSavedVitalsKeyRef.current = savedVitalsKey
+
+                setCharacterRef.current((currentCharacter) =>
+                    currentCharacter.id === characterId
+                        ? {
+                              ...currentCharacter,
+                              characterVersion: savedCharacter.characterVersion
+                          }
+                        : currentCharacter
+                )
+
+                queryClient.invalidateQueries({ queryKey: ["coterieVitals"] })
+                queryClient.invalidateQueries({ queryKey: ["characters", characterId] })
+            } catch (error) {
+                if (cancelled) return
+                console.warn("Failed to autosave character vitals:", error)
+                retryTimeout = window.setTimeout(saveLatestVitals, RETRY_DELAY_MS)
+            }
+        }
+
+        const timeout = window.setTimeout(saveLatestVitals, AUTOSAVE_DELAY_MS)
+
+        return () => {
+            cancelled = true
+            window.clearTimeout(timeout)
+            if (retryTimeout !== undefined) {
+                window.clearTimeout(retryTimeout)
+            }
+        }
+    }, [character.id, isAuthenticated, queryClient, vitalsKey])
+}

--- a/frontend/src/hooks/useCharacters.tsx
+++ b/frontend/src/hooks/useCharacters.tsx
@@ -24,6 +24,8 @@ export const useCreateCharacter = () => {
             api.createCharacter(data),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["characters"] })
+            queryClient.invalidateQueries({ queryKey: ["coteries"] })
+            queryClient.invalidateQueries({ queryKey: ["coterieVitals"] })
         }
     })
 }
@@ -42,6 +44,8 @@ export const useUpdateCharacter = () => {
         onSuccess: (_, variables) => {
             queryClient.invalidateQueries({ queryKey: ["characters"] })
             queryClient.invalidateQueries({ queryKey: ["characters", variables.id] })
+            queryClient.invalidateQueries({ queryKey: ["coteries"] })
+            queryClient.invalidateQueries({ queryKey: ["coterieVitals"] })
         }
     })
 }
@@ -53,6 +57,8 @@ export const useDeleteCharacter = () => {
         mutationFn: (id: string) => api.deleteCharacter(id),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["characters"] })
+            queryClient.invalidateQueries({ queryKey: ["coteries"] })
+            queryClient.invalidateQueries({ queryKey: ["coterieVitals"] })
         }
     })
 }

--- a/frontend/src/hooks/useCoteries.tsx
+++ b/frontend/src/hooks/useCoteries.tsx
@@ -9,6 +9,17 @@ export const useCoteries = (enabled = true) => {
     })
 }
 
+export const useCoterieVitals = (enabled = true) => {
+    return useQuery({
+        queryKey: ["coterieVitals"],
+        queryFn: () => api.getCoterieVitals(),
+        enabled,
+        refetchInterval: enabled ? 2000 : false,
+        refetchIntervalInBackground: false,
+        refetchOnWindowFocus: true
+    })
+}
+
 export const useCoterie = (id: string | null) => {
     return useQuery({
         queryKey: ["coteries", id],
@@ -40,6 +51,7 @@ export const useCreateCoterie = () => {
         mutationFn: (data: { name: string }) => api.createCoterie(data),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["coteries"] })
+            queryClient.invalidateQueries({ queryKey: ["coterieVitals"] })
         }
     })
 }
@@ -53,6 +65,7 @@ export const useUpdateCoterie = () => {
         onSuccess: (_, variables) => {
             queryClient.invalidateQueries({ queryKey: ["coteries"] })
             queryClient.invalidateQueries({ queryKey: ["coteries", variables.id] })
+            queryClient.invalidateQueries({ queryKey: ["coterieVitals"] })
         }
     })
 }
@@ -64,6 +77,7 @@ export const useDeleteCoterie = () => {
         mutationFn: (id: string) => api.deleteCoterie(id),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ["coteries"] })
+            queryClient.invalidateQueries({ queryKey: ["coterieVitals"] })
         }
     })
 }
@@ -150,6 +164,7 @@ export const useAddCharacterToCoterie = () => {
         onSuccess: (_, variables) => {
             queryClient.invalidateQueries({ queryKey: ["coteries"] })
             queryClient.invalidateQueries({ queryKey: ["coteries", variables.coterieId] })
+            queryClient.invalidateQueries({ queryKey: ["coterieVitals"] })
         }
     })
 }
@@ -163,6 +178,7 @@ export const useRemoveCharacterFromCoterie = () => {
         onSuccess: (_, variables) => {
             queryClient.invalidateQueries({ queryKey: ["coteries"] })
             queryClient.invalidateQueries({ queryKey: ["coteries", variables.coterieId] })
+            queryClient.invalidateQueries({ queryKey: ["coterieVitals"] })
         }
     })
 }

--- a/frontend/src/pages/CreatorPage.tsx
+++ b/frontend/src/pages/CreatorPage.tsx
@@ -172,6 +172,8 @@ export default function CreatorPage() {
         } as CharacterType & { id: string; characterVersion: number })
 
         await queryClient.invalidateQueries({ queryKey: ["characters"] })
+        await queryClient.invalidateQueries({ queryKey: ["coteries"] })
+        await queryClient.invalidateQueries({ queryKey: ["coterieVitals"] })
     }
 
     const isCurrentCharacterEmpty = () =>
@@ -298,6 +300,8 @@ export default function CreatorPage() {
                     0
             } as CharacterType & { id: string; characterVersion: number })
             await queryClient.invalidateQueries({ queryKey: ["characters"] })
+            await queryClient.invalidateQueries({ queryKey: ["coteries"] })
+            await queryClient.invalidateQueries({ queryKey: ["coterieVitals"] })
 
             const action = pendingSwitchAction
             closeNameBeforeSwitchModal()

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -167,6 +167,8 @@ export default function LandingPage() {
             }
 
             await queryClient.invalidateQueries({ queryKey: ["characters"] })
+            await queryClient.invalidateQueries({ queryKey: ["coteries"] })
+            await queryClient.invalidateQueries({ queryKey: ["coterieVitals"] })
 
             notifications.show({
                 title: "Character saved",

--- a/frontend/src/pages/MePage.tsx
+++ b/frontend/src/pages/MePage.tsx
@@ -35,7 +35,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query"
 import { Link } from "@tanstack/react-router"
 import { Buffer } from "buffer"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { z } from "zod"
 import { RAW_GOLD, RAW_GREY, RAW_RED, rgba } from "~/theme/colors"
 import ChatWindow from "~/character_sheet/components/ChatWindow"
@@ -68,6 +68,7 @@ import {
     useAddCharacterToCoterie,
     useCoteries,
     useCoterieInvites,
+    useCoterieVitals,
     useCreateCoterie,
     useCreateCoterieInvite,
     useDeleteCoterie,
@@ -96,6 +97,8 @@ import {
 import CharactersSection from "./sections/CharactersSection"
 import CoteriesSection from "./sections/CoteriesSection"
 import UserProfileSection from "./sections/UserProfileSection"
+import { getCharacterVitals, isCharacterVitals } from "~/utils/characterVitals"
+import type { CharacterVitals } from "~/utils/characterVitals"
 
 const backgrounds = [club, brokenDoor, city, bloodGuy, batWoman, alley]
 const topbarHeight = 52
@@ -244,6 +247,18 @@ const MePage = () => {
     } = useAuth()
     const { data: characters } = useCharacters(isAuthenticated)
     const { data: coteries } = useCoteries(isAuthenticated)
+    const { data: coterieVitals } = useCoterieVitals(isAuthenticated)
+    const vitalsByCharacterId = useMemo(() => {
+        const vitalsMap: Record<string, CharacterVitals> = {}
+
+        ;(coterieVitals || []).forEach((vitals) => {
+            if (isCharacterVitals(vitals)) {
+                vitalsMap[vitals.characterId] = vitals
+            }
+        })
+
+        return vitalsMap
+    }, [coterieVitals])
     const [character, setCharacter] = useCharacterLocalStorage()
     const computedColorScheme = useComputedColorScheme("dark", {
         getInitialValueInEffect: true
@@ -1726,6 +1741,9 @@ const MePage = () => {
     const userCharacters = (characters as Character[]) || []
     const userCoteries = coteries || []
     const ownedCharacters = userCharacters.filter((c) => !c.shared)
+    const currentCoterieForSummary = coterieForSummary
+        ? (userCoteries.find((coterie) => coterie.id === coterieForSummary.id) ?? coterieForSummary)
+        : null
 
     // Find the currently loaded character in the list by ID
     const currentlyLoadedCharacter = character.id
@@ -1860,6 +1878,7 @@ const MePage = () => {
                                     }
                                     setCoterieForSummary={setCoterieForSummary}
                                     setCoterieSummaryModalOpened={setCoterieSummaryModalOpened}
+                                    vitalsByCharacterId={vitalsByCharacterId}
                                 />
                             </Stack>
                         </Container>
@@ -2447,17 +2466,21 @@ const MePage = () => {
                     <Group gap="xs">
                         <IconUsers size={20} />
                         <Text fw={600} size="lg">
-                            Coterie Summary: {coterieForSummary?.name || ""}
+                            Coterie Summary: {currentCoterieForSummary?.name || ""}
                         </Text>
                     </Group>
                 }
                 centered
                 size="xl"
             >
-                {coterieForSummary &&
-                coterieForSummary.members &&
-                coterieForSummary.members.length > 0 ? (
-                    <CoterieSummaryContent members={coterieForSummary.members} theme={theme} />
+                {currentCoterieForSummary &&
+                currentCoterieForSummary.members &&
+                currentCoterieForSummary.members.length > 0 ? (
+                    <CoterieSummaryContent
+                        members={currentCoterieForSummary.members}
+                        theme={theme}
+                        vitalsByCharacterId={vitalsByCharacterId}
+                    />
                 ) : (
                     <Text c="dimmed">No members in this coterie.</Text>
                 )}
@@ -2504,10 +2527,15 @@ const MePage = () => {
 type CoterieSummaryContentProps = {
     members: Array<{ characterId: string; playerNickname?: string | null; character?: Character }>
     theme: ReturnType<typeof useMantineTheme>
+    vitalsByCharacterId: Record<string, CharacterVitals>
 }
 
 // TODOdin: Move modals and their contents from MePage into their own components under sections/
-const CoterieSummaryContent = ({ members, theme }: CoterieSummaryContentProps) => {
+const CoterieSummaryContent = ({
+    members,
+    theme,
+    vitalsByCharacterId
+}: CoterieSummaryContentProps) => {
     const getDisciplineCategory = (
         disciplineName: DisciplineName
     ): "physical" | "social" | "mental" => {
@@ -2660,14 +2688,26 @@ const CoterieSummaryContent = ({ members, theme }: CoterieSummaryContentProps) =
         }
     }
 
+    const memberSummaries = useMemo(
+        () =>
+            members.flatMap((member) => {
+                const character = parseCharacterData(member.character?.data)
+                if (!character) return []
+
+                return {
+                    member,
+                    character,
+                    strength: calculateCharacterStrength(character),
+                    clan: character.clan ? clans[character.clan] : null,
+                    vitals: vitalsByCharacterId[member.characterId] ?? getCharacterVitals(character)
+                }
+            }),
+        [members, vitalsByCharacterId]
+    )
+
     return (
         <Grid>
-            {members.map((member) => {
-                const character = parseCharacterData(member.character?.data)
-                if (!character) return null
-
-                const strength = calculateCharacterStrength(character)
-                const clan = character.clan ? clans[character.clan] : null
+            {memberSummaries.map(({ member, character, strength, clan, vitals }) => {
                 const backgroundColor = getBackgroundColor(strength.dominant)
                 const borderColor = getBorderColor(strength.dominant)
                 const playerName =
@@ -2722,6 +2762,20 @@ const CoterieSummaryContent = ({ members, theme }: CoterieSummaryContentProps) =
                                     <Text size="sm" c="dimmed" truncate="end">
                                         Player: {playerName}
                                     </Text>
+                                    <Group gap="xs">
+                                        <Badge size="sm" color="red" variant="light">
+                                            Hunger {vitals.hunger}/5
+                                        </Badge>
+                                        <Badge size="lg" color="grape" variant="filled">
+                                            Willpower {vitals.currentWillpower}/{vitals.willpower}
+                                        </Badge>
+                                        <Badge size="sm" color="blue" variant="light">
+                                            Humanity {vitals.humanity}/10
+                                            {vitals.humanityStains > 0
+                                                ? ` · ${vitals.humanityStains} stains`
+                                                : ""}
+                                        </Badge>
+                                    </Group>
                                 </Stack>
                             </Group>
                         </Paper>

--- a/frontend/src/pages/sections/CoteriesSection.tsx
+++ b/frontend/src/pages/sections/CoteriesSection.tsx
@@ -24,8 +24,11 @@ import {
     IconUserMinus,
     IconUsers
 } from "@tabler/icons-react"
+import { useMemo } from "react"
 import { parseCharacterData } from "~/utils/characterData"
 import type { CoterieCharacter, CoteriePlayerResponse, CoterieResponse } from "~/utils/api"
+import { getCharacterVitals } from "~/utils/characterVitals"
+import type { CharacterVitals } from "~/utils/characterVitals"
 
 type Character = CoterieCharacter
 type CoteriePlayer = CoteriePlayerResponse
@@ -51,6 +54,7 @@ type CoteriesSectionProps = {
     ) => void
     setCoterieForSummary: (coterie: Coterie) => void
     setCoterieSummaryModalOpened: (opened: boolean) => void
+    vitalsByCharacterId: Record<string, CharacterVitals>
 }
 
 const CoteriesSection = ({
@@ -65,8 +69,35 @@ const CoteriesSection = ({
     handleShowCharacterSummary,
     handleRemoveCharacterFromCoterie,
     setCoterieForSummary,
-    setCoterieSummaryModalOpened
+    setCoterieSummaryModalOpened,
+    vitalsByCharacterId
 }: CoteriesSectionProps) => {
+    const memberDetailsByCharacterId = useMemo(() => {
+        const details: Record<
+            string,
+            {
+                playerName?: string
+                vitals?: CharacterVitals
+            }
+        > = {}
+
+        userCoteries.forEach((coterie) => {
+            coterie.members?.forEach((member) => {
+                const characterData = parseCharacterData(member.character?.data)
+                const liveVitals = vitalsByCharacterId[member.characterId]
+
+                details[member.characterId] = {
+                    playerName: member.playerNickname?.trim() || characterData?.player || undefined,
+                    vitals:
+                        liveVitals ??
+                        (characterData ? getCharacterVitals(characterData) : undefined)
+                }
+            })
+        })
+
+        return details
+    }, [userCoteries, vitalsByCharacterId])
+
     return (
         <Card p="xl" withBorder style={{ backgroundColor: "rgba(0, 0, 0, 0.8)" }}>
             <Group gap="md" mb="md" justify="space-between">
@@ -248,10 +279,10 @@ const CoteriesSection = ({
                                         </Text>
                                         <Stack gap="xs">
                                             {coterie.members.map((member) => {
-                                                const memberCharData = parseCharacterData(
-                                                    member.character?.data
-                                                )
-                                                const memberPlayerName = memberCharData?.player
+                                                const memberDetails =
+                                                    memberDetailsByCharacterId[member.characterId]
+                                                const memberPlayerName = memberDetails?.playerName
+                                                const memberVitals = memberDetails?.vitals
                                                 return member.character ? (
                                                     <Group
                                                         key={member.characterId}
@@ -277,6 +308,41 @@ const CoteriesSection = ({
                                                             ) : null}
                                                         </Group>
                                                         <Group gap="xs">
+                                                            {memberVitals ? (
+                                                                <>
+                                                                    <Badge
+                                                                        size="xs"
+                                                                        color="red"
+                                                                        variant="light"
+                                                                    >
+                                                                        Hunger {memberVitals.hunger}
+                                                                        /5
+                                                                    </Badge>
+                                                                    <Badge
+                                                                        size="md"
+                                                                        color="grape"
+                                                                        variant="filled"
+                                                                    >
+                                                                        Willpower{" "}
+                                                                        {
+                                                                            memberVitals.currentWillpower
+                                                                        }
+                                                                        /{memberVitals.willpower}
+                                                                    </Badge>
+                                                                    <Badge
+                                                                        size="xs"
+                                                                        color="blue"
+                                                                        variant="light"
+                                                                    >
+                                                                        Humanity{" "}
+                                                                        {memberVitals.humanity}/10
+                                                                        {memberVitals.humanityStains >
+                                                                        0
+                                                                            ? ` · ${memberVitals.humanityStains} stains`
+                                                                            : ""}
+                                                                    </Badge>
+                                                                </>
+                                                            ) : null}
                                                             <ActionIcon
                                                                 color="red"
                                                                 variant="light"
@@ -301,8 +367,7 @@ const CoteriesSection = ({
                                                                             member.characterId,
                                                                             {
                                                                                 characterName:
-                                                                                    member
-                                                                                        .character
+                                                                                    member.character
                                                                                         ?.name,
                                                                                 coterieName:
                                                                                     coterie.name

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -164,6 +164,35 @@ export type StartImpersonationResponse = {
 
 type ApiTimestamp = string
 
+export type UpdateCharacterVitalsPayload = {
+    willpower: number
+    humanity: number
+    ephemeral: {
+        hunger: number
+        superficialWillpowerDamage: number
+        aggravatedWillpowerDamage: number
+        humanityStains: number
+    }
+}
+
+export type UpdateCharacterVitalsResponse = {
+    id: string
+    characterVersion: number
+    updatedAt: ApiTimestamp
+}
+
+export type CoterieVitalsResponse = {
+    coterieId: string
+    characterId: string
+    hunger: number
+    willpower: number
+    currentWillpower: number
+    humanity: number
+    humanityStains: number
+    characterVersion: number
+    updatedAt: ApiTimestamp
+}
+
 export type CoterieCharacter = {
     id: string
     name: string
@@ -313,10 +342,16 @@ export const api = {
         apiRequest<unknown>("/characters", { method: "POST", body: data }),
     updateCharacter: (id: string, data: { name?: string; data?: unknown; version?: number }) =>
         apiRequest<unknown>(`/characters/${id}`, { method: "PUT", body: data }),
+    updateCharacterVitals: (id: string, data: UpdateCharacterVitalsPayload) =>
+        apiRequest<UpdateCharacterVitalsResponse>(`/characters/${id}/vitals`, {
+            method: "PATCH",
+            body: data
+        }),
     deleteCharacter: (id: string) => apiRequest<void>(`/characters/${id}`, { method: "DELETE" }),
 
     // Coteries
     getCoteries: () => apiRequest<CoterieResponse[]>("/coteries"),
+    getCoterieVitals: () => apiRequest<CoterieVitalsResponse[]>("/coteries/vitals"),
     getCoterie: (id: string) => apiRequest<CoterieResponse>(`/coteries/${id}`),
     createCoterie: (data: { name: string }) =>
         apiRequest<CoterieResponse>("/coteries", { method: "POST", body: data }),

--- a/frontend/src/utils/characterVitals.ts
+++ b/frontend/src/utils/characterVitals.ts
@@ -1,0 +1,49 @@
+import type { Character } from "~/data/Character"
+
+export type CharacterVitals = {
+    characterId?: string
+    coterieId?: string
+    hunger: number
+    willpower: number
+    currentWillpower: number
+    humanity: number
+    humanityStains: number
+    characterVersion?: number
+    updatedAt?: string
+}
+
+export const getCurrentWillpower = (character: Character) => {
+    const superficialDamage = character.ephemeral?.superficialWillpowerDamage ?? 0
+    const aggravatedDamage = character.ephemeral?.aggravatedWillpowerDamage ?? 0
+
+    return Math.max(character.willpower - superficialDamage - aggravatedDamage, 0)
+}
+
+export const getCharacterVitals = (character: Character): CharacterVitals => ({
+    hunger: character.ephemeral?.hunger ?? 0,
+    willpower: character.willpower,
+    currentWillpower: getCurrentWillpower(character),
+    humanity: character.humanity,
+    humanityStains: character.ephemeral?.humanityStains ?? 0,
+    characterVersion: character.characterVersion
+})
+
+export const isCharacterVitals = (
+    value: unknown
+): value is CharacterVitals & {
+    characterId: string
+    coterieId: string
+} => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return false
+
+    const vitals = value as Partial<CharacterVitals>
+    return (
+        typeof vitals.characterId === "string" &&
+        typeof vitals.coterieId === "string" &&
+        typeof vitals.hunger === "number" &&
+        typeof vitals.willpower === "number" &&
+        typeof vitals.currentWillpower === "number" &&
+        typeof vitals.humanity === "number" &&
+        typeof vitals.humanityStains === "number"
+    )
+}


### PR DESCRIPTION
## What changed

- add a validated, owner-only character vitals update endpoint for hunger, total/current willpower, humanity, and humanity stains
- autosave play-state vitals from the character sheet after a short debounce, with retry on transient failures
- expose lightweight coterie-member vitals to coterie owners and joined players
- refresh coterie vitals every two seconds while the coteries view is active
- show hunger, humanity, and prominently styled willpower in coterie lists and summaries, with persisted-character fallbacks
- keep React Query character and coterie-vitals caches synchronized after saves
- cover live vitals updates, access rules, and participant visibility with backend tests

## Why

Coterie views previously displayed character identity and build information but not changing play-state values. Updating those values also required saving the full character payload, making live coterie status harder to keep current.

## Impact

Authenticated character owners can update their live vitals through a narrow API. Every participant in a coterie can see current hunger, willpower, and humanity without repeatedly loading full character records. Existing full-character save behavior remains unchanged, and non-owners remain unable to edit shared characters.

## Validation

- frontend formatting: local `oxfmt`
- frontend lint: `corepack pnpm run lint`
- frontend build/typecheck: `corepack pnpm run build`
- frontend tests: `corepack pnpm run test:run` (77 passed)
- backend formatting: local `oxfmt`
- backend lint: `corepack pnpm run lint`
- backend build/typecheck: `corepack pnpm run build`
- backend tests: `corepack pnpm run test:run` (24 passed)
