### PR TITLE
Fix mobile willpower reroll selection

### DIFF
--- a/frontend/src/character_sheet/components/diceRollModal/DiceRollModal.tsx
+++ b/frontend/src/character_sheet/components/diceRollModal/DiceRollModal.tsx
@@ -308,6 +308,7 @@ const DiceRollModal = ({
     const rollDice = () => {
         const countToUse = activeTab === "selected" ? selectedPoolDiceCount : diceCount
         const bloodDiceCount = Math.min(hunger, countToUse)
+        setSelectedDiceIds(new Set())
 
         if (isMobile) {
             startRoll()
@@ -368,21 +369,47 @@ const DiceRollModal = ({
         return dice.filter((d) => !d.isBloodDie && !d.isRolling)
     }, [dice])
 
-    const rerollableDice = useMemo(() => {
-        return dice.filter((d) => !d.isBloodDie && !d.isRolling && d.value < 6)
-    }, [dice])
+    const selectedRerollDiceIds = useMemo(
+        () =>
+            new Set(nonBloodDice.filter((die) => selectedDiceIds.has(die.id)).map((die) => die.id)),
+        [nonBloodDice, selectedDiceIds]
+    )
 
-    const canReroll = useMemo(() => {
-        if (!character || !setCharacter || editDisabledReason) return false
+    const availableWillpower = useMemo(() => {
+        if (!character) return 0
         const totalWillpowerDamage =
             (character.ephemeral?.superficialWillpowerDamage ?? 0) +
             (character.ephemeral?.aggravatedWillpowerDamage ?? 0)
-        const availableWillpower = character.willpower - totalWillpowerDamage
-        if (isMobile) {
-            return availableWillpower > 0 && rerollableDice.length > 0
+        return character.willpower - totalWillpowerDamage
+    }, [character])
+
+    const rerollDisabledReason = useMemo(() => {
+        if (editDisabledReason) return editDisabledReason
+        if (!character || !setCharacter) return undefined
+        if (availableWillpower <= 0) return "No willpower left to reroll"
+        if (nonBloodDice.length === 0) return "No regular dice available to reroll"
+        if (selectedRerollDiceIds.size === 0) {
+            return "Select up to 3 regular dice to reroll"
         }
-        return availableWillpower > 0 && selectedDiceIds.size > 0 && selectedDiceIds.size <= 3
-    }, [character, editDisabledReason, selectedDiceIds, isMobile, rerollableDice.length])
+        return undefined
+    }, [
+        editDisabledReason,
+        character,
+        setCharacter,
+        availableWillpower,
+        nonBloodDice.length,
+        selectedRerollDiceIds.size
+    ])
+
+    const canReroll = useMemo(() => {
+        return (
+            !!character &&
+            !!setCharacter &&
+            !rerollDisabledReason &&
+            selectedRerollDiceIds.size > 0 &&
+            selectedRerollDiceIds.size <= 3
+        )
+    }, [character, setCharacter, rerollDisabledReason, selectedRerollDiceIds.size])
 
     const handleDieClick = useCallback(
         (dieId: number, isBloodDie: boolean) => {
@@ -404,19 +431,10 @@ const DiceRollModal = ({
     const handleReroll = () => {
         if (!character || !setCharacter || editDisabledReason || !canReroll) return
 
-        const totalWillpowerDamage =
-            (character.ephemeral?.superficialWillpowerDamage ?? 0) +
-            (character.ephemeral?.aggravatedWillpowerDamage ?? 0)
-        const availableWillpower = character.willpower - totalWillpowerDamage
         if (availableWillpower <= 0) return
 
-        let diceIdsToReroll: Set<number>
-        if (isMobile) {
-            diceIdsToReroll = new Set(rerollableDice.map((d) => d.id))
-        } else {
-            diceIdsToReroll = selectedDiceIds
-            if (diceIdsToReroll.size === 0) return
-        }
+        const diceIdsToReroll = selectedRerollDiceIds
+        if (diceIdsToReroll.size === 0 || diceIdsToReroll.size > 3) return
 
         setCharacter({
             ...character,
@@ -426,6 +444,17 @@ const DiceRollModal = ({
                     (character.ephemeral?.superficialWillpowerDamage ?? 0) + 1
             }
         })
+
+        try {
+            posthog.capture("dice-roll-reroll", {
+                mode: activeTab === "selected" ? "selected-pool" : "custom",
+                is_mobile: isMobile,
+                reroll_dice_count: diceIdsToReroll.size,
+                available_willpower_before: availableWillpower
+            })
+        } catch (error) {
+            console.warn("PostHog dice reroll tracking failed:", error)
+        }
 
         if (isMobile) {
             const rerolledDice = dice.filter((d) => diceIdsToReroll.has(d.id))
@@ -464,6 +493,7 @@ const DiceRollModal = ({
                     : ""
 
             setDice(newDice)
+            setSelectedDiceIds(new Set())
 
             const autoShareDiceRolls = getAutoShareDiceRolls()
             if (
@@ -897,14 +927,12 @@ const DiceRollModal = ({
                     )}
                 </Group>
 
-                {isMobile ? null : (
-                    <DiceContainer
-                        primaryColor={primaryColor}
-                        onDieClick={handleDieClick}
-                        selectedDiceIds={selectedDiceIds}
-                        isMobile={isMobile}
-                    />
-                )}
+                <DiceContainer
+                    primaryColor={primaryColor}
+                    onDieClick={handleDieClick}
+                    selectedDiceIds={selectedDiceIds}
+                    isMobile={isMobile}
+                />
 
                 <AnimatePresence>
                     {dice.length > 0 && !dice.some((d) => d.isRolling) ? (
@@ -913,16 +941,10 @@ const DiceRollModal = ({
                             results={calculateSuccesses.results}
                             totalSuccesses={calculateSuccesses.totalSuccesses}
                             primaryColor={primaryColor}
-                            onReroll={
-                                nonBloodDice.length > 0 && character && setCharacter
-                                    ? handleReroll
-                                    : undefined
-                            }
+                            onReroll={character && setCharacter ? handleReroll : undefined}
                             canReroll={canReroll}
-                            rerollDisabledReason={editDisabledReason}
-                            selectedDiceCount={selectedDiceIds.size}
-                            rerollableDiceCount={rerollableDice.length}
-                            isMobile={isMobile}
+                            rerollDisabledReason={rerollDisabledReason}
+                            selectedDiceCount={selectedRerollDiceIds.size}
                         />
                     ) : null}
                 </AnimatePresence>

--- a/frontend/src/character_sheet/components/diceRollModal/parts/DiceContainer.tsx
+++ b/frontend/src/character_sheet/components/diceRollModal/parts/DiceContainer.tsx
@@ -33,6 +33,36 @@ const DiceContainer = ({
         }))
     )
 
+    if (isMobile) {
+        return (
+            <Group
+                justify="center"
+                gap="xs"
+                wrap="wrap"
+                style={{ minHeight: dice.length > 0 ? "50px" : 0, flexShrink: 0 }}
+            >
+                <AnimatePresence>
+                    {dice.map((die, index) => (
+                        <Die
+                            key={die.id}
+                            value={die.value}
+                            isRolling={die.isRolling}
+                            primaryColor={die.isBloodDie ? vtmRed : primaryColor}
+                            onClick={() => onDieClick?.(die.id, die.isBloodDie)}
+                            isSelected={selectedDiceIds.has(die.id)}
+                            isSelectable={
+                                !die.isBloodDie && !die.isRolling && onDieClick !== undefined
+                            }
+                            isMobile
+                            isBloodDie={die.isBloodDie}
+                            ariaLabel={`${die.isBloodDie ? "Hunger" : "Regular"} die ${index + 1} showing ${die.value === 10 ? "0" : die.value}`}
+                        />
+                    ))}
+                </AnimatePresence>
+            </Group>
+        )
+    }
+
     return (
         <Group
             justify="center"
@@ -141,7 +171,7 @@ const DiceContainer = ({
                                 isSelectable={
                                     !die.isBloodDie && !die.isRolling && onDieClick !== undefined
                                 }
-                                isMobile={false}
+                                isMobile={isMobile}
                                 isBloodDie={die.isBloodDie}
                             />
                         </motion.div>

--- a/frontend/src/character_sheet/components/diceRollModal/parts/Die.tsx
+++ b/frontend/src/character_sheet/components/diceRollModal/parts/Die.tsx
@@ -14,6 +14,7 @@ type DieProps = {
     isSelectable?: boolean
     isMobile?: boolean
     isBloodDie?: boolean
+    ariaLabel?: string
 }
 
 const Die = ({
@@ -26,7 +27,8 @@ const Die = ({
     isSelected = false,
     isSelectable = false,
     isMobile = false,
-    isBloodDie = false
+    isBloodDie = false,
+    ariaLabel
 }: DieProps) => {
     const theme = useMantineTheme()
     const colorValue = primaryColor.startsWith("#")
@@ -38,14 +40,26 @@ const Die = ({
         const dieColor = isBloodDie ? vtmRed : colorValue
 
         return (
-            <motion.div
+            <motion.button
+                type="button"
                 initial={{ scale: 0, opacity: 0 }}
                 animate={{ scale: 1, opacity: 1 }}
                 exit={{ scale: 0, opacity: 0 }}
                 transition={{ duration: 0.2 }}
                 whileTap={isSelectable ? { scale: 0.9 } : undefined}
                 onClick={isSelectable ? onClick : undefined}
-                style={{ cursor: isSelectable ? "pointer" : "default" }}
+                disabled={!isSelectable}
+                aria-label={
+                    ariaLabel ?? `${isBloodDie ? "Hunger" : "Regular"} die showing ${displayValue}`
+                }
+                aria-pressed={isSelectable ? isSelected : undefined}
+                style={{
+                    cursor: isSelectable ? "pointer" : "default",
+                    appearance: "none",
+                    background: "none",
+                    border: 0,
+                    padding: 0
+                }}
             >
                 <Badge
                     size="xl"
@@ -70,7 +84,7 @@ const Die = ({
                 >
                     {displayValue}
                 </Badge>
-            </motion.div>
+            </motion.button>
         )
     }
     const seededRandom = (offset: number = 0) => {

--- a/frontend/src/character_sheet/components/diceRollModal/parts/SuccessResults.tsx
+++ b/frontend/src/character_sheet/components/diceRollModal/parts/SuccessResults.tsx
@@ -7,6 +7,7 @@ import criticalIcon from "~/resources/diceResults/critical.svg"
 import bloodSuccessIcon from "~/resources/diceResults/blood-success.svg"
 import bloodCriticalIcon from "~/resources/diceResults/blood-critical.svg"
 import bestialFailureIcon from "~/resources/diceResults/bestial-failure.svg"
+import { globals } from "~/globals"
 
 type SuccessResult = {
     type: "success" | "critical" | "blood-success" | "blood-critical" | "bestial-failure"
@@ -20,8 +21,6 @@ type SuccessResultsProps = {
     onReroll?: () => void
     canReroll?: boolean
     selectedDiceCount?: number
-    rerollableDiceCount?: number
-    isMobile?: boolean
     rerollDisabledReason?: string
 }
 
@@ -32,8 +31,6 @@ const SuccessResults = ({
     onReroll,
     canReroll = false,
     selectedDiceCount = 0,
-    rerollableDiceCount = 0,
-    isMobile = false,
     rerollDisabledReason
 }: SuccessResultsProps) => {
     const theme = useMantineTheme()
@@ -114,12 +111,15 @@ const SuccessResults = ({
                         </Text>
                         {onReroll ? (
                             <Group gap="xs" wrap="nowrap">
-                                {isMobile ? (
-                                    rerollableDiceCount > 0 ? (
-                                        <Badge size="sm" variant="filled" color={primaryColor}>
-                                            {rerollableDiceCount} WP rerollable
-                                        </Badge>
-                                    ) : null
+                                {rerollDisabledReason === "No willpower left to reroll" ? (
+                                    <Badge size="sm" variant="outline" color="gray">
+                                        No WP left
+                                    </Badge>
+                                ) : rerollDisabledReason ===
+                                  "Select up to 3 regular dice to reroll" ? (
+                                    <Badge size="sm" variant="outline" color={primaryColor}>
+                                        Tap dice
+                                    </Badge>
                                 ) : selectedDiceCount > 0 ? (
                                     <Badge size="sm" variant="filled" color={primaryColor}>
                                         {selectedDiceCount}/3
@@ -128,25 +128,28 @@ const SuccessResults = ({
                                 <Tooltip
                                     label={
                                         rerollDisabledReason ??
-                                        (isMobile
-                                            ? rerollableDiceCount > 0
-                                                ? `Reroll ${rerollableDiceCount} non-success dice (1 willpower)`
-                                                : "No dice to reroll"
-                                            : selectedDiceCount > 0
-                                              ? `Reroll ${selectedDiceCount} dice (1 willpower)`
-                                              : "Select up to 3 non-blood dice to reroll (1 willpower)")
+                                        (selectedDiceCount > 0
+                                            ? `Reroll ${selectedDiceCount} dice (1 willpower)`
+                                            : "Select up to 3 regular dice to reroll (1 willpower)")
                                     }
                                     zIndex={2100}
+                                    events={globals.tooltipTriggerEvents}
                                 >
-                                    <ActionIcon
-                                        color={primaryColor}
-                                        variant={canReroll ? "filled" : "outline"}
-                                        onClick={onReroll}
-                                        disabled={!canReroll}
-                                        size="sm"
-                                    >
-                                        <IconRefresh size={16} />
-                                    </ActionIcon>
+                                    <span style={{ display: "inline-flex" }}>
+                                        <ActionIcon
+                                            aria-label="Reroll selected dice with willpower"
+                                            color={primaryColor}
+                                            variant={canReroll ? "filled" : "outline"}
+                                            onClick={onReroll}
+                                            disabled={!canReroll}
+                                            size="sm"
+                                            style={
+                                                !canReroll ? { pointerEvents: "none" } : undefined
+                                            }
+                                        >
+                                            <IconRefresh size={16} />
+                                        </ActionIcon>
+                                    </span>
                                 </Tooltip>
                             </Group>
                         ) : null}

--- a/frontend/src/test/diceRollReroll.test.tsx
+++ b/frontend/src/test/diceRollReroll.test.tsx
@@ -1,0 +1,141 @@
+import { MantineProvider } from "@mantine/core"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import DiceRollModal from "~/character_sheet/components/diceRollModal/DiceRollModal"
+import type { DieResult } from "~/character_sheet/components/diceRollModal/parts/DiceContainer"
+import { useCharacterSheetStore } from "~/character_sheet/stores/characterSheetStore"
+import { useDiceRollModalStore } from "~/character_sheet/stores/diceRollModalStore"
+import { getBasicTestCharacter } from "./testUtils"
+
+const mocks = vi.hoisted(() => ({
+    isMobile: true,
+    capture: vi.fn()
+}))
+
+vi.mock("@mantine/hooks", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("@mantine/hooks")>()
+    return {
+        ...actual,
+        useMediaQuery: () => mocks.isMobile
+    }
+})
+
+vi.mock("posthog-js", () => ({
+    default: {
+        capture: (...args: unknown[]) => mocks.capture(...args),
+        get_distinct_id: () => "test-distinct-id"
+    }
+}))
+
+class ResizeObserverStub {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+}
+
+vi.stubGlobal("ResizeObserver", ResizeObserverStub)
+
+Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+        matches: mocks.isMobile,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn()
+    }))
+})
+
+const renderModalWithDice = (
+    dice: DieResult[],
+    character = getBasicTestCharacter(),
+    setCharacter = vi.fn()
+) => {
+    useDiceRollModalStore.getState().open()
+    useDiceRollModalStore.getState().setDice(dice)
+
+    render(
+        <MantineProvider>
+            <DiceRollModal primaryColor="red" character={character} setCharacter={setCharacter} />
+        </MantineProvider>
+    )
+
+    return { setCharacter }
+}
+
+describe("DiceRollModal willpower rerolls", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks()
+        mocks.isMobile = true
+        mocks.capture.mockClear()
+        vi.spyOn(globalThis.crypto, "getRandomValues").mockImplementation((array) => {
+            const values = array as Uint32Array
+            values[0] = 0x80000000
+            return array
+        })
+        useCharacterSheetStore.getState().resetSelectedDicePool()
+        useDiceRollModalStore.getState().reset()
+    })
+
+    it("lets mobile players choose and reroll at most three regular dice", () => {
+        const dice: DieResult[] = [1, 2, 3, 4].map((value, index) => ({
+            id: index + 1,
+            value,
+            isRolling: false,
+            isBloodDie: false
+        }))
+        const { setCharacter } = renderModalWithDice(dice)
+        const rerollButton = screen.getByRole("button", {
+            name: "Reroll selected dice with willpower"
+        })
+
+        expect(rerollButton).toBeDisabled()
+        expect(screen.getByText("Tap dice")).toBeInTheDocument()
+
+        for (const index of [1, 2, 3, 4]) {
+            fireEvent.click(
+                screen.getByRole("button", {
+                    name: `Regular die ${index} showing ${index}`
+                })
+            )
+        }
+
+        expect(screen.getByText("3/3")).toBeInTheDocument()
+        expect(rerollButton).toBeEnabled()
+
+        fireEvent.click(rerollButton)
+
+        expect(setCharacter).toHaveBeenCalledWith(
+            expect.objectContaining({
+                ephemeral: expect.objectContaining({ superficialWillpowerDamage: 1 })
+            })
+        )
+        expect(useDiceRollModalStore.getState().dice.map((die) => die.value)).toEqual([6, 6, 6, 4])
+        expect(mocks.capture).toHaveBeenCalledWith("dice-roll-reroll", {
+            mode: "custom",
+            is_mobile: true,
+            reroll_dice_count: 3,
+            available_willpower_before: 4
+        })
+    })
+
+    it("shows the player when no willpower remains", async () => {
+        const character = getBasicTestCharacter()
+        character.ephemeral.superficialWillpowerDamage = character.willpower
+
+        renderModalWithDice([{ id: 1, value: 3, isRolling: false, isBloodDie: false }], character)
+
+        expect(screen.getByText("No WP left")).toBeInTheDocument()
+
+        const rerollButton = screen.getByRole("button", {
+            name: "Reroll selected dice with willpower"
+        })
+        expect(rerollButton).toBeDisabled()
+
+        fireEvent.mouseEnter(rerollButton.parentElement!)
+        expect(await screen.findByText("No willpower left to reroll")).toBeInTheDocument()
+    })
+})


### PR DESCRIPTION
## What changed

- render compact, selectable dice in the mobile roller instead of hiding the dice grid
- use the same 1–3 selected regular dice rule on mobile and desktop
- prevent stale selections from carrying into a new roll
- show visible “Tap dice” and “No WP left” states, with a touch-capable tooltip for the full reason
- add accessible labels and selected state to compact dice and the reroll action
- capture successful willpower rerolls for regression monitoring
- add focused mobile tests covering selection, the three-die limit, willpower spending, analytics, and the depleted-willpower state

## Why

The affected Android session used a current Chrome version and a 384 px viewport, so treating an unresolved media query as mobile does not address the reported environment. The underlying design problem was that reroll mechanics diverged by viewport: the mobile layout hid the only dice-selection UI and used a separate automatic reroll path.

This change removes that dependency. Whichever layout is selected, players have a complete reroll interaction, and mobile rerolls now follow the V5 limit of up to three regular dice.

## Validation

- `pnpm run test:run` — 130 passing
- `pnpm run lint`
- `pnpm exec vite build`
- changed-file formatting check

A standalone repository-wide `tsc --noEmit` still reports pre-existing errors outside this patch.