### PR TITLE
Track Homebrew item creation

### DIFF
--- a/backend/src/homebrew.test.ts
+++ b/backend/src/homebrew.test.ts
@@ -8,6 +8,10 @@ const workosMock = vi.hoisted(() => ({
     user: { id: "brew-author", email: "brew-author@progeny.invalid" }
 }))
 
+const trackerMock = vi.hoisted(() => ({
+    trackEvent: vi.fn(async () => undefined)
+}))
+
 vi.mock("./config/workos.js", () => ({
     WORKOS_CLIENT_ID: "test-client-id",
     workos: {
@@ -19,6 +23,8 @@ vi.mock("./config/workos.js", () => ({
         }
     }
 }))
+
+vi.mock("./utils/tracker.js", () => trackerMock)
 
 const AUTHOR_ID = "brew-author"
 const ADMIN_ID = "brew-admin"
@@ -77,6 +83,7 @@ describe("Homebrew collections and library", () => {
     })
 
     beforeEach(async () => {
+        trackerMock.trackEvent.mockClear()
         for (const table of [
             schema.impersonationSessions,
             schema.homebrewComments,
@@ -205,6 +212,77 @@ describe("Homebrew collections and library", () => {
             coteries: [{ id: COTERIE_ID, name: "Homebrew Coterie" }]
         })
         expect(context.json()[0].items).toHaveLength(2)
+    })
+
+    it("tracks each newly created Homebrew item by type", async () => {
+        const collection = await createCollection()
+
+        expect(trackerMock.trackEvent).toHaveBeenCalledWith(
+            "homebrew_item_created",
+            { itemType: "discipline", collectionItemCount: 2 },
+            AUTHOR_ID,
+            expect.anything()
+        )
+        expect(trackerMock.trackEvent).toHaveBeenCalledWith(
+            "homebrew_item_created",
+            { itemType: "power", collectionItemCount: 2 },
+            AUTHOR_ID,
+            expect.anything()
+        )
+
+        trackerMock.trackEvent.mockClear()
+        const updated = await app.inject({
+            method: "PUT",
+            url: `/homebrew/collections/${collection.id}`,
+            headers: csrfHeaders,
+            payload: {
+                name: "Night Arts",
+                shortDescription: "Strange powers for a nocturnal chronicle.",
+                description: "An original collection.",
+                tags: ["gothic"],
+                contentWarning: "Body horror",
+                items: [
+                    {
+                        id: collection.items[0]!.id,
+                        kind: "discipline",
+                        name: "Noctis",
+                        summary: "Shape the living dark.",
+                        description: "",
+                        logo: ""
+                    },
+                    {
+                        id: collection.items[1]!.id,
+                        kind: "power",
+                        name: "Drink the Moon",
+                        summary: "Draw strength from moonlight.",
+                        description: "",
+                        discipline: "Noctis",
+                        level: 1,
+                        dicePool: "Resolve + Noctis",
+                        rouseChecks: 1,
+                        amalgamPrerequisites: []
+                    },
+                    {
+                        id: "homebrew-merit",
+                        kind: "merit",
+                        name: "Moonlit Favor",
+                        summary: "A supernatural ally owes you a boon.",
+                        description: "",
+                        costs: [1],
+                        excludes: []
+                    }
+                ]
+            }
+        })
+
+        expect(updated.statusCode, updated.body).toBe(200)
+        expect(trackerMock.trackEvent).toHaveBeenCalledTimes(1)
+        expect(trackerMock.trackEvent).toHaveBeenCalledWith(
+            "homebrew_item_created",
+            { itemType: "merit", collectionItemCount: 3 },
+            AUTHOR_ID,
+            expect.anything()
+        )
     })
 
     it("enables a collection for every character in its owner's account", async () => {

--- a/backend/src/routes/homebrew.ts
+++ b/backend/src/routes/homebrew.ts
@@ -92,6 +92,23 @@ const countKinds = (snapshot: HomebrewCollectionSnapshot) =>
         return counts
     }, {})
 
+const getNewHomebrewItemKinds = (
+    existingItemIds: Set<string>,
+    items: HomebrewCollectionInput["items"]
+) => items.filter((item) => !item.id || !existingItemIds.has(item.id)).map((item) => item.kind)
+
+const trackCreatedHomebrewItems = async (
+    itemKinds: string[],
+    collectionItemCount: number,
+    userId: string,
+    request: Parameters<typeof trackEvent>[3]
+) =>
+    Promise.all(
+        itemKinds.map((itemType) =>
+            trackEvent("homebrew_item_created", { itemType, collectionItemCount }, userId, request)
+        )
+    )
+
 const sendHomebrewStorageLimitError = (reply: FastifyReply) =>
     reply.code(413).send({ error: new HomebrewStorageLimitError().message })
 
@@ -454,6 +471,12 @@ export async function homebrewRoutes(fastify: FastifyInstance) {
                     request.user!.id,
                     request
                 )
+                await trackCreatedHomebrewItems(
+                    parsedInput.data.items.map((item) => item.kind),
+                    collection?.items.length ?? 0,
+                    request.user!.id,
+                    request
+                )
                 reply.code(201).send(collection)
             } catch (error) {
                 if (error instanceof HomebrewStorageLimitError) {
@@ -481,13 +504,23 @@ export async function homebrewRoutes(fastify: FastifyInstance) {
                 return sendHomebrewValidationError(reply, parsedInput.error.issues)
             }
             try {
-                reply.send(
-                    await replaceHomebrewCollection(
-                        collection.id,
-                        parsedInput.data,
-                        request.user!.id
-                    )
+                const existingItems = await getHomebrewCollectionSnapshot(collection.id)
+                const createdItemKinds = getNewHomebrewItemKinds(
+                    new Set(existingItems?.items.map((item) => item.id)),
+                    parsedInput.data.items
                 )
+                const updatedCollection = await replaceHomebrewCollection(
+                    collection.id,
+                    parsedInput.data,
+                    request.user!.id
+                )
+                await trackCreatedHomebrewItems(
+                    createdItemKinds,
+                    updatedCollection?.items.length ?? 0,
+                    request.user!.id,
+                    request
+                )
+                reply.send(updatedCollection)
             } catch (error) {
                 if (error instanceof HomebrewStorageLimitError)
                     return sendHomebrewStorageLimitError(reply)


### PR DESCRIPTION
## What changed

- Capture a `homebrew_item_created` PostHog event for every newly saved Homebrew item.
- Include the item type and collection item count, covering both initial collection creation and later additions.
- Add route coverage and bring repository formatting/lint compliance up to date.

## Why

Homebrew collection tracking previously captured only total item counts, so PostHog could not distinguish what rule types users were creating.

## Validation

- `pnpm run lint`
- `pnpm --dir backend run test:run` (65 tests)
- `pnpm --dir backend run build`
- `pnpm --dir frontend run test:run` (165 tests)
- `pnpm --dir frontend run build`
